### PR TITLE
fixed selecting deleted buffer

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -215,8 +215,9 @@ scroll bar."
   (when yascroll:delay-to-hide
     (run-with-idle-timer yascroll:delay-to-hide nil
                          (lambda (buffer)
-                           (with-current-buffer buffer
-                             (yascroll:hide-scroll-bar)))
+                           (when (buffer-live-p buffer)
+                              (with-current-buffer buffer
+                                (yascroll:hide-scroll-bar))))
                          (current-buffer))))
 
 (defun yascroll:choose-scroll-bar ()


### PR DESCRIPTION
If we close buffer before scrollbar is hidden then we receive "Error running timer: selecting deleted buffer"
